### PR TITLE
Fix OpenGl version naming.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ mod settings;
 fn main() {
     let settings = settings::Settings::new();
 
-    let opengl = OpenGL::_3_2;
+    let opengl = OpenGL::V3_2;
     let window: PistonWindow =
         WindowSettings::new("Sudoku",
             [(settings.wind_size.x as u32), (settings.wind_size.y as u32)])


### PR DESCRIPTION
Was failing to build, I guess the PistonDevelopers/shader_version crate changed their naming convention. It builds correctly after this fix.

Also, thanks for writing and publishing this project. I've just started getting my feet wet with piston and it has been very useful as a reference.
