### PR TITLE
Cover all patterns

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -141,6 +141,7 @@ impl App {
             &Button::Mouse(button) => {
                 self.on_mouse_click(&button);
             }
+            &Button::Joystick(_) => {}
         }
     }
 


### PR DESCRIPTION
Fix this error with using piston v0.13.0.

```
src/app.rs:137:9: 144:10 error: non-exhaustive patterns: `&Joystick(_)` not covered [E0004]
src/app.rs:137         match button {
src/app.rs:138             &Button::Keyboard(key) => {
src/app.rs:139                 self.on_key_down(&key);
src/app.rs:140             },
src/app.rs:141             &Button::Mouse(button) => {
src/app.rs:142                 self.on_mouse_click(&button);
```
