### PR TITLE
Fix compilation error with Piston 0.17.0

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
     let settings = settings::Settings::new();
 
     let opengl = OpenGL::V3_2;
-    let window: GlutinWindow =
+    let mut window: GlutinWindow =
         WindowSettings::new("Sudoku",
             [(settings.wind_size.x as u32), (settings.wind_size.y as u32)])
         .exit_on_esc(true)
@@ -35,7 +35,8 @@ fn main() {
 
     let mut app = app::App::new(settings);
 
-    for e in window.events() {
+    let mut events = window.events();
+    while let Some(e) = events.next(&mut window) {
         if let Some(args) = e.render_args() {
             app.on_render(&args, gl, cache);
         }


### PR DESCRIPTION
This patch fixes the following compilation error with Piston 0.17.0:

  error: the trait `core::iter::Iterator` is not implemented for the type `event_loop::WindowEvents`

This fix is inspired by a similar fix in Piston-Tutorials:

  https://github.com/PistonDevelopers/Piston-Tutorials/commit/f41a83767a57285e03d82aedc330071d0b4d9135

Signed-off-by: Christophe Vu-Brugier cvubrugier@fastmail.fm
