### PR TITLE
rename Joystick to Controller

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -138,7 +138,7 @@ impl App {
             &Button::Mouse(button) => {
                 self.on_mouse_click(&button);
             }
-            &Button::Joystick(_) => {}
+            &Button::Controller(_) => {}
         }
     }
 


### PR DESCRIPTION
master fails to build with latest version of dependencies

Piston renamed Joystick to Controller in version 0.19

```
src/app.rs:141:14: 141:33 error: no associated item named `Joystick` found for type `input::Button` in the current scope
src/app.rs:141             &Button::Joystick(_) => {}
                            ^~~~~~~~~~~~~~~~~~~
```

ref: https://github.com/PistonDevelopers/piston/commit/fb2a8beab8d9582951503e03863e92c8eda9accb

This PR should fix that
